### PR TITLE
Create a servlet for the conversion call to geocoding API

### DIFF
--- a/src/main/java/com/google/sps/servlets/ConvertLocationServlet.java
+++ b/src/main/java/com/google/sps/servlets/ConvertLocationServlet.java
@@ -28,20 +28,16 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 
-@WebServlet("/query")
+@WebServlet("/convert")
 public class PlacesAPI extends HttpServlet {
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         response.setContentType("text/html");
         String lat = request.getParameter("lat");
-        String lon = request.getParameter("lon");
-        String radius = request.getParameter("radius");
-        String type = request.getParameter("type");
-        String searchTerms = request.getParameter("searchTerms");
+        String lng = request.getParameter("lng");
         String apiKey = "AIzaSyDbEPugXWcqo1q6b-X_pd09a0Zaj3trDOw";
-        String sURL = "https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=" + lat + "," + lon + "&radius=" + radius + "&type=" + type + "&keyword=" + searchTerms + "&key=" + apiKey;
-
+        String sURL = "https://maps.googleapis.com/maps/api/geocode/json?latlng=" + lat + "," + lng + "&result_type=street_address&key=" + apiKey;
         // Connect to the URL using java's native library
         URL url = new URL(sURL);
         URLConnection requestURL = url.openConnection();

--- a/src/main/webapp/js/query.js
+++ b/src/main/webapp/js/query.js
@@ -45,8 +45,6 @@ function tryQuery() {
             errorEl.innerText = error;
         });
 }
-
-const apiKey = 'AIzaSyDbEPugXWcqo1q6b-X_pd09a0Zaj3trDOw';
 let queryArr;
 
 function loadPage() {
@@ -86,10 +84,8 @@ function getLocation() {
 function convertLocation(location) {
     let lat = location.lat;
     let long = location.lng;
-    const url = 'https://maps.googleapis.com/maps/api/geocode/json?latlng=' + lat + ',' + long + '&result_type=street_address&key=' + apiKey;
-    const proxyurl = "https://cors-anywhere.herokuapp.com/";
 
-    return fetch(proxyurl + url)
+    return fetch(`/convert?lat=${lat}&lng=${long}`)
         .then(response => response.json())
         .then(response => {
             console.log(response.results[0].formatted_address);


### PR DESCRIPTION
Move the call to the geocoding API into a java servlet. This change ports the convertLocation() function in query.js, into a servlet called ConvertLocationServlet.java. The convertLocation() function now calls the servlet which will handle the API call. This is made for consistency with the other API calls in the backend